### PR TITLE
PDF - Image Conversion

### DIFF
--- a/app/lib/pdf2img.ts
+++ b/app/lib/pdf2img.ts
@@ -1,0 +1,89 @@
+export interface PdfConversionResult {
+	imageUrl: string;
+	file: File | null;
+	error?: string;
+}
+
+let pdfjsLib: any = null;
+let isLoading = false;
+let loadPromise: Promise<any> | null = null;
+
+async function loadPdfJs(): Promise<any> {
+	if (pdfjsLib) return pdfjsLib;
+	if (loadPromise) return loadPromise;
+
+	isLoading = true;
+	// @ts-expect-error - pdfjs-dist/build/pdf.mjs is not a module
+	loadPromise = import("pdfjs-dist/build/pdf.mjs").then((lib) => {
+		// Set the worker source to use local file
+		lib.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+		pdfjsLib = lib;
+		isLoading = false;
+		return lib;
+	});
+
+	return loadPromise;
+}
+
+export async function convertPdfToImage(
+	file: File
+): Promise<PdfConversionResult> {
+	try {
+		const lib = await loadPdfJs();
+
+		const arrayBuffer = await file.arrayBuffer();
+		const pdf = await lib.getDocument({ data: arrayBuffer }).promise;
+		const page = await pdf.getPage(1);
+
+		const viewport = page.getViewport({ scale: 4 });
+		const canvas = document.createElement("canvas");
+		const context = canvas.getContext("2d");
+
+		canvas.width = viewport.width;
+		canvas.height = viewport.height;
+
+		if (context) {
+			context.imageSmoothingEnabled = true;
+			context.imageSmoothingQuality = "high";
+		}
+
+		await page.render({ canvasContext: context!, viewport }).promise;
+
+		return new Promise((resolve) => {
+			canvas.toBlob(
+				(blob) => {
+					if (blob) {
+						// Create a File from the blob with the same name as the pdf
+						const originalName = file.name.replace(/\.pdf$/i, "");
+						const imageFile = new File(
+							[blob],
+							`${originalName}.png`,
+							{
+								type: "image/png",
+							}
+						);
+
+						resolve({
+							imageUrl: URL.createObjectURL(blob),
+							file: imageFile,
+						});
+					} else {
+						resolve({
+							imageUrl: "",
+							file: null,
+							error: "Failed to create image blob",
+						});
+					}
+				},
+				"image/png",
+				1.0
+			); // Set quality to maximum (1.0)
+		});
+	} catch (err) {
+		return {
+			imageUrl: "",
+			file: null,
+			error: `Failed to convert PDF: ${err}`,
+		};
+	}
+}

--- a/app/routes/upload.tsx
+++ b/app/routes/upload.tsx
@@ -3,7 +3,7 @@ import { useState, type FormEvent } from "react";
 import FileUploader from "~/components/FileUploader";
 import { generateUUID } from "~/lib/utils";
 import { usePuterStore } from "~/lib/puter";
-import { convertPdfToImage } from "~/lib/utils"
+import { convertPdfToImage } from "~/lib/pdf2img"
 import { data, useNavigate } from "react-router";
 import { prepareInstructions } from "../../constants";
 


### PR DESCRIPTION
This pull request introduces a new utility for converting PDF files to images and updates the import path in the upload route to use this new module. The main change is the addition of the `pdf2img.ts` utility, which encapsulates PDF-to-image conversion logic using `pdfjs-dist`, improving modularity and maintainability.

### PDF-to-image conversion utility

* Added a new file `pdf2img.ts` that provides the `convertPdfToImage` function for converting the first page of a PDF file to a PNG image. This function handles loading the `pdfjs-dist` library, rendering the PDF page to a canvas, and exporting it as a PNG image blob and file.

### Refactoring imports

* Updated the import in `upload.tsx` to use `convertPdfToImage` from the new `pdf2img.ts` utility instead of the previous location, ensuring the route uses the centralized conversion logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF uploads now generate a high‑quality PNG preview of the first page for quick viewing.
  * Converter loads only when needed, reducing initial load time during upload.
  * Clearer error messages are shown if conversion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->